### PR TITLE
[ito] update excon to fix security issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,10 @@ gem 'fog-aws'
 # 画像のリサイズ
 gem 'mini_magick'
 
+# fogがexconを使用しいているが、exconの0.71.0未満には脆弱性があるとのこと
+# https://github.com/yuki-data/freemarket_sample_myself/network/alert/Gemfile.lock/excon/open
+gem "excon", ">= 0.71.0"
+
 # hamlをテンプレートで使うため
  gem "haml-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     equalizer (0.0.11)
     erubi (1.9.0)
     erubis (2.7.0)
-    excon (0.68.0)
+    excon (0.71.1)
     execjs (2.7.0)
     faster (0.0.1)
     fastri (0.3.1.1)
@@ -366,6 +366,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   debase
   debride
+  excon (>= 0.71.0)
   faster
   fastri
   fog-aws


### PR DESCRIPTION
# what
- exconをbundle updateし0.71.0以上のバージョンにした
# why
- fogがexconを使用しいているが、exconの0.71.0未満には脆弱性があるとのこと
- https://github.com/yuki-data/freemarket_sample_myself/network/alert/Gemfile.lock/excon/open